### PR TITLE
Support Statistics Api for the Support Us Page Data

### DIFF
--- a/backend/src/controller/support-controller.js
+++ b/backend/src/controller/support-controller.js
@@ -112,6 +112,21 @@ export const getGoldMembers = async (req, res) => {
     }
 };
 
+export const getSupportStatistics = async (req, res) => {
+    try {
+        const stats = await supportService.getSupportStatistics();
+        res.status(200).json({
+            success: true,
+            data: stats
+        });
+    } catch (error) {
+        res.status(500).json({
+            success: false,
+            message: error.message || 'Internal server error'
+        });
+    }
+};
+
 // export const getUserTotalSupport = async (req, res) => {
 //     try {
 //         const userId = req.user.id;
@@ -145,5 +160,15 @@ export const getGoldMembers = async (req, res) => {
 //             success: false,
 //             message: error.message || 'Internal server error'
 //         });
+//     }
+// };
+
+// export const cancelMonthlySupport = async (req, res) => {
+//     try {
+//         const userId = req.user.id;
+//         const result = await supportService.cancelMonthlySupport(userId);
+//         res.status(200).json({ success: true, ...result });
+//     } catch (error) {
+//         res.status(400).json({ success: false, message: error.message });
 //     }
 // };

--- a/backend/src/models/SupportUs.js
+++ b/backend/src/models/SupportUs.js
@@ -29,6 +29,9 @@ const SupportSchema = new mongoose.Schema({
     supportAt: {
         type: Date,
         default: Date.now
+    },
+    cancelledAt : {
+        type : Date
     }
 }, { timestamps: true });
 

--- a/backend/src/routes/support-routes.js
+++ b/backend/src/routes/support-routes.js
@@ -4,6 +4,7 @@ import {
     getUserSupports, 
     getAllSupports, 
     getGoldMembers, 
+    getSupportStatistics,
     // getUserTotalSupport, 
     // cancelMonthlySupport 
 } from '../controller/support-controller.js';
@@ -20,11 +21,14 @@ router.get('/my-supports', authenticate, getUserSupports);
 // Get current user's total support amount
 // router.get('/my-total', authenticate, getUserTotalSupport);
 
-// Cancel monthly support
-// router.delete('/cancel/:supportId', authenticate, cancelMonthlySupport);
+// Cancel monthly support for current user
+// router.post('/cancel-monthly', authenticate, cancelMonthlySupport);
 
 // Admin routes (you might want to add admin middleware here)
 router.get('/all', getAllSupports);
 router.get('/gold-members', authenticate, getGoldMembers);
+
+// Statistics for Support Us page
+router.get('/statistics', getSupportStatistics);
 
 export default router;

--- a/backend/src/services/support-service.js
+++ b/backend/src/services/support-service.js
@@ -134,6 +134,48 @@ class SupportService {
     //         throw error;
     //     }
     // }
+
+
+    async getSupportStatistics() {
+        const Support = this.supportRepository.model;
+        // One-time funds
+        const [oneTimeFundsResult] = await Support.aggregate([
+            { $match: { supportType: "one-time" } },
+            { $group: { _id: null, totalFunds: { $sum: "$amount" } } }
+        ]);
+        const oneTimeFunds = oneTimeFundsResult?.totalFunds || 0;
+
+        // Monthly funds calculation
+        const monthlySupports = await Support.find({ supportType: "monthly" });
+        let monthlyFunds = 0;
+        const now = new Date();
+        monthlySupports.forEach(support => {
+            const start = support.createdAt;
+            const end = support.cancelledAt || now;
+            // Calculate the number of months between start and end
+            let months = (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+            // If the end day is after or equal to the start day, count the current month
+            if (end.getDate() >= start.getDate()) months++;
+            if (months < 1) months = 1; // At least 1 month
+            monthlyFunds += support.amount * months;
+        });
+
+        // Other stats
+        const supporterCount = await Support.distinct("userId").then(arr => arr.length);
+        const goldMembers = await Support.countDocuments({ isGoldMember: true, supportType: "monthly" });
+        const oneTimeCount = await Support.countDocuments({ supportType: "one-time" });
+        const monthlyCount = await Support.countDocuments({ supportType: "monthly" });
+
+        return {
+            oneTimeFunds,
+            monthlyFunds,
+            totalFunds: oneTimeFunds + monthlyFunds,
+            supporterCount,
+            goldMembers,
+            oneTimeCount,
+            monthlyCount
+        };
+    }
 }
 
 export default SupportService;


### PR DESCRIPTION
Files Changed for the additiion of the logic of the statistics api for the Support Us page:-
1. SupportUs Routes
2. SupportUs controllers
3. SupportUs-service
4. SupportUs model

End Point:-

GET     localhost:3000/support/statistics

ss of the postman testing:-
<img width="1455" height="957" alt="Screenshot 2025-07-19 145239" src="https://github.com/user-attachments/assets/01bbfafc-a2ff-4d54-a954-f180c519e110" />
