### PR TITLE
"Comic Chapters" user frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,7 +37,7 @@ import {RESEARCH_BASE_URL, FOUNDATION_BASE_URL} from './utils/constants.js'
 import PrivacyPolicy from './pages/Policy/PrivacyPolicy.jsx';
 import RefundPolicy from './pages/Policy/Refund.jsx';
 import TermsOfService from './pages/Policy/TermsofService.jsx';
-
+import ComicChap from './components/Comics/comicChap.jsx'
 
 function App() {
   useEffect(() => {
@@ -128,6 +128,7 @@ function App() {
             <Route path="/createAvatar" element={<SignupStep3/>}/>
             <Route path="/cart" element={<Cart/>}/>
             <Route path="/comics" element={<Comic/>}/>
+            <Route path="/comicChap/:comicId/chapters" element={<ComicChap></ComicChap>}></Route>
             <Route path="/privacy-policy" element={<PrivacyPolicy/>}/>
             <Route path='/games' element={<Games></Games>}></Route>
             <Route path='/terms-of-service' element={<TermsOfService/>}></Route>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -129,6 +129,7 @@ function App() {
             <Route path="/cart" element={<Cart/>}/>
             <Route path="/comics" element={<Comic/>}/>
             <Route path="/comicChap/:comicId/chapters" element={<ComicChap></ComicChap>}></Route>
+            <Route path="/comicChap/:comicId/chapters/pdfView" element={<ComicChap></ComicChap>}></Route>
             <Route path="/privacy-policy" element={<PrivacyPolicy/>}/>
             <Route path='/games' element={<Games></Games>}></Route>
 

--- a/frontend/src/components/Body.jsx
+++ b/frontend/src/components/Body.jsx
@@ -29,11 +29,13 @@ const Body = () => {
     return <LogoLoader />;
   }
 
+  const isReaderView = location.pathname.includes("/comicChap/") && location.pathname.includes("/pdfView");
+
   return (
     <div>
-      <Navbar />
+       {!isReaderView && <Navbar />}
       <Outlet />
-      <Footer />
+      {!isReaderView && <Footer />}
     </div>
   );
 };

--- a/frontend/src/components/Comics/Card.jsx
+++ b/frontend/src/components/Comics/Card.jsx
@@ -1,9 +1,14 @@
 import React from "react";
-
+import { useNavigate } from 'react-router-dom';
 const Card = ({ comic }) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/comicChap/${comic._id}/chapters`);
+  };
   return (
     <div className="w-[132.5rem] flex justify-center items-center bg-white">
-      <div className="w-[12.5rem] overflow-hidden">
+      <div  onClick={handleClick} className="w-[12.5rem] overflow-hidden">
         <img
           src={
             comic.coverImg ||

--- a/frontend/src/components/Comics/Comic.jsx
+++ b/frontend/src/components/Comics/Comic.jsx
@@ -30,6 +30,8 @@ function Comic() {
     sliderRef.current.scrollBy({ left: 260, behavior: 'smooth' });
   };
 
+  const reversedComics = comics.slice().reverse();
+
   return (
     <div className="w-11/12 lg:w-2/3 mx-auto mt-12">
       <div className="flex justify-between items-center mb-4 ">
@@ -53,12 +55,12 @@ function Comic() {
         >
           <>
             {/* First 2 as available */}
-            {comics.slice(0, 2).map((comic) => (
+            {reversedComics.slice(0, 2).map((comic) => (
               <ComicCard key={comic._id} comic={comic} />
             ))}
 
             {/* Rest as sold out */}
-            {comics.slice(2).map((comic) => (
+            {reversedComics.slice(2).map((comic) => (
               <SoldCard key={comic._id} comic={comic} />
             ))}
           </>

--- a/frontend/src/components/Comics/ComicChap.jsx
+++ b/frontend/src/components/Comics/ComicChap.jsx
@@ -1,81 +1,93 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { fetchChapter } from "../../services/ComicService.js"; // adjust path as needed
 
 const ComicChap = () => {
   const { comicId } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
   const [chapters, setChapters] = useState([]);
+  const [selectedPdf, setSelectedPdf] = useState(null);
+
+  const isReaderView =
+    location.pathname.includes("/comicChap/") && location.pathname.includes("/pdfView");
 
   useEffect(() => {
     const getChapters = async () => {
       try {
         const data = await fetchChapter(comicId);
-        console.log(data)
         setChapters(data);
       } catch (error) {
         console.error("Failed to fetch chapters:", error);
       }
     };
-
     getChapters();
   }, [comicId]);
 
-  return (
-    <div className="bg-white rounded-2xl shadow-xl p-4 sm:p-8 max-w-5xl mx-auto mt-10">
-      <div className="flex flex-col sm:flex-row items-center justify-between mb-4 sm:mb-6 gap-2">
-        <h2 className="text-xl sm:text-2xl font-bold text-gray-800 flex items-center gap-2 sm:gap-3">
-          <svg className="w-5 h-5 sm:w-6 sm:h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-          </svg>
-          All Chapters
-        </h2>
-        <div className="text-xs sm:text-sm text-gray-500">
-          {chapters.length} chapter{chapters.length !== 1 ? "s" : ""} available
+  // Show PDF full-screen if in pdfView route
+  if (isReaderView && selectedPdf) {
+    return (
+      <div className="h-screen w-screen bg-black flex flex-col">
+        <div className="bg-[#2c2c2c] text-white px-6 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => navigate(`/comicChap/${comicId}/chapters`)}
+              className="text-white hover:text-gray-300 text-lg sm:text-xl"
+            >
+              {/* Unicode arrow or you can use an icon */}
+              &#8592;
+            </button>
+            <span className="text-sm sm:text-base font-medium">
+              {selectedPdf.title}
+            </span>
+          </div>
         </div>
-      </div>
 
-      <div className="space-y-3 sm:space-y-4">
+        <iframe
+          src={`${selectedPdf.url}#toolbar=0&navpanes=0&scrollbar=0`}
+          title="Chapter PDF"
+          className="flex-1 w-full"
+          frameBorder="0"
+        ></iframe>
+      </div>
+    );
+  }
+
+  // Normal view with chapter list
+  return (
+    <div className="bg-white p-2 sm:p-8 max-w-5xl mx-auto mt-10">
+      <div>
         {chapters.map((chap) => (
           <div
             key={chap._id}
-            className="group bg-gray-50 hover:bg-white border-2 border-gray-200 hover:border-red-200 rounded-xl p-3 sm:p-6 transition-all duration-300 hover:shadow-lg"
+            className="group bg-white hover:bg-gray-50 border-1 border-gray-200 transition-all duration-300 hover:shadow-lg"
+            onClick={() => {
+              setSelectedPdf({ url: chap.chapPdf, title: chap.title });
+              navigate(`/comicChap/${comicId}/chapters/pdfView`);
+            }}
           >
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-              <div className="flex items-start sm:items-center gap-3 sm:gap-4 flex-1 w-full">
-                <div className="w-16 h-23 sm:w-20 sm:h-25 bg-gradient-to-br from-red-500 to-red-700 flex-shrink-0 flex items-center justify-center shadow-md">
-                  <img src={chap.chapImage} alt="Chapter" className="w-full h-full object-contain border border-black" />
+              <div className="flex items-start sm:items-center w-full">
+                <div className="w-32 h-17 sm:w-32 sm:h-17 flex-shrink-0 flex items-center justify-center shadow-md">
+                  <img
+                    src={chap.chapImage}
+                    alt="Chapter"
+                    className="w-full h-full object-fill"
+                  />
                 </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 sm:gap-3 mb-2">
-                    <h3 className="text-lg sm:text-xl font-semibold text-gray-800 truncate">
-                      {chap.title}
-                    </h3>
-                  </div>
-                  <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-6 text-xs sm:text-sm text-gray-600">
-                    <div className="flex items-center gap-1">
-                      <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
-                      </svg>
-                      <span>Chapter {chap.chapNum}</span>
-                    </div>
-                    {chap.releaseDate && (
-                      <div className="flex items-center gap-1">
-                        <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                        </svg>
-                        <span>{new Date(chap.releaseDate).toLocaleDateString()}</span>
-                      </div>
-                    )}
-                    {chap.views && (
-                      <div className="flex items-center gap-1">
-                        <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                        </svg>
-                        <span>{chap.views > 1000 ? (chap.views / 1000).toFixed(1) + 'K' : chap.views} views</span>
-                      </div>
-                    )}
-                  </div>
+                <div className="flex justify-between items-center w-full">
+                  <h3 className="text-xl font-medium text-gray-800 truncate max-w-[200px] sm:max-w-xs ml-6">
+                    {chap.title}
+                  </h3>
+                  {chap.releaseDate && (
+                    <span className="text-base font-normal text-gray-600 whitespace-nowrap mr-15">
+                      {new Date(chap.releaseDate).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    </span>
+                  )}
                 </div>
               </div>
             </div>

--- a/frontend/src/components/Comics/ComicChap.jsx
+++ b/frontend/src/components/Comics/ComicChap.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
-import { fetchChapter } from "../../services/ComicService.js"; // adjust path as needed
+import { fetchChapter } from "../../services/ComicService.js"; 
 
 const ComicChap = () => {
   const { comicId } = useParams();
@@ -24,7 +24,6 @@ const ComicChap = () => {
     getChapters();
   }, [comicId]);
 
-  // Show PDF full-screen if in pdfView route
   if (isReaderView && selectedPdf) {
     return (
       <div className="h-screen w-screen bg-black flex flex-col">
@@ -34,7 +33,6 @@ const ComicChap = () => {
               onClick={() => navigate(`/comicChap/${comicId}/chapters`)}
               className="text-white hover:text-gray-300 text-lg sm:text-xl"
             >
-              {/* Unicode arrow or you can use an icon */}
               &#8592;
             </button>
             <span className="text-sm sm:text-base font-medium">
@@ -42,7 +40,6 @@ const ComicChap = () => {
             </span>
           </div>
         </div>
-
         <iframe
           src={`${selectedPdf.url}#toolbar=0&navpanes=0&scrollbar=0`}
           title="Chapter PDF"
@@ -52,49 +49,47 @@ const ComicChap = () => {
       </div>
     );
   }
-
-  // Normal view with chapter list
-  return (
-    <div className="bg-white p-2 sm:p-8 max-w-5xl mx-auto mt-10">
-      <div>
-        {chapters.map((chap) => (
-          <div
-            key={chap._id}
-            className="group bg-white hover:bg-gray-50 border-1 border-gray-200 transition-all duration-300 hover:shadow-lg"
-            onClick={() => {
-              setSelectedPdf({ url: chap.chapPdf, title: chap.title });
-              navigate(`/comicChap/${comicId}/chapters/pdfView`);
-            }}
-          >
-            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-              <div className="flex items-start sm:items-center w-full">
-                <div className="w-32 h-17 sm:w-32 sm:h-17 flex-shrink-0 flex items-center justify-center shadow-md">
-                  <img
-                    src={chap.chapImage}
-                    alt="Chapter"
-                    className="w-full h-full object-fill"
-                  />
-                </div>
-                <div className="flex justify-between items-center w-full">
-                  <h3 className="text-xl font-medium text-gray-800 truncate max-w-[200px] sm:max-w-xs ml-6">
-                    {chap.title}
-                  </h3>
-                  {chap.releaseDate && (
-                    <span className="text-base font-normal text-gray-600 whitespace-nowrap mr-15">
-                      {new Date(chap.releaseDate).toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      })}
-                    </span>
-                  )}
-                </div>
+return (
+  <div className="bg-white p-2 sm:p-8 max-w-5xl mx-auto mt-10">
+    <div>
+      {chapters.map((chap) => (
+        <div
+          key={chap._id}
+          className="group bg-white hover:bg-gray-50 border-1 border-gray-200 transition-all duration-300 hover:shadow-lg"
+          onClick={() => {
+            setSelectedPdf({ url: chap.chapPdf, title: chap.title });
+            navigate(`/comicChap/${comicId}/chapters/pdfView`);
+          }}
+        >
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div className="flex items-start sm:items-center w-full">
+              <div className="w-32 h-17 sm:w-32 sm:h-17 flex-shrink-0 flex items-center justify-center shadow-md">
+                <img
+                  src={chap.chapImage}
+                  alt="Chapter"
+                  className="w-full h-full object-fill"
+                />
+              </div>
+              <div className="flex justify-between items-center w-full">
+                <h3 className="text-xl font-medium text-gray-800 truncate max-w-[200px] sm:max-w-xs ml-6">
+                  {chap.title}
+                </h3>
+                {chap.releaseDate && (
+                  <span className="text-base font-normal text-gray-600 whitespace-nowrap mr-15">
+                    {new Date(chap.releaseDate).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </span>
+                )}
               </div>
             </div>
           </div>
-        ))}
-      </div>
+        </div>
+      ))}
     </div>
+  </div>
   );
 };
 

--- a/frontend/src/components/Comics/ComicChap.jsx
+++ b/frontend/src/components/Comics/ComicChap.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { fetchChapter } from "../../services/ComicService.js"; // adjust path as needed
+
+const ComicChap = () => {
+  const { comicId } = useParams();
+  const [chapters, setChapters] = useState([]);
+
+  useEffect(() => {
+    const getChapters = async () => {
+      try {
+        const data = await fetchChapter(comicId);
+        console.log(data)
+        setChapters(data);
+      } catch (error) {
+        console.error("Failed to fetch chapters:", error);
+      }
+    };
+
+    getChapters();
+  }, [comicId]);
+
+  return (
+    <div className="bg-white rounded-2xl shadow-xl p-4 sm:p-8 max-w-5xl mx-auto mt-10">
+      <div className="flex flex-col sm:flex-row items-center justify-between mb-4 sm:mb-6 gap-2">
+        <h2 className="text-xl sm:text-2xl font-bold text-gray-800 flex items-center gap-2 sm:gap-3">
+          <svg className="w-5 h-5 sm:w-6 sm:h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+          All Chapters
+        </h2>
+        <div className="text-xs sm:text-sm text-gray-500">
+          {chapters.length} chapter{chapters.length !== 1 ? "s" : ""} available
+        </div>
+      </div>
+
+      <div className="space-y-3 sm:space-y-4">
+        {chapters.map((chap) => (
+          <div
+            key={chap._id}
+            className="group bg-gray-50 hover:bg-white border-2 border-gray-200 hover:border-red-200 rounded-xl p-3 sm:p-6 transition-all duration-300 hover:shadow-lg"
+          >
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+              <div className="flex items-start sm:items-center gap-3 sm:gap-4 flex-1 w-full">
+                <div className="w-16 h-23 sm:w-20 sm:h-25 bg-gradient-to-br from-red-500 to-red-700 flex-shrink-0 flex items-center justify-center shadow-md">
+                  <img src={chap.chapImage} alt="Chapter" className="w-full h-full object-contain border border-black" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 sm:gap-3 mb-2">
+                    <h3 className="text-lg sm:text-xl font-semibold text-gray-800 truncate">
+                      {chap.title}
+                    </h3>
+                  </div>
+                  <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:gap-6 text-xs sm:text-sm text-gray-600">
+                    <div className="flex items-center gap-1">
+                      <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+                      </svg>
+                      <span>Chapter {chap.chapNum}</span>
+                    </div>
+                    {chap.releaseDate && (
+                      <div className="flex items-center gap-1">
+                        <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                        <span>{new Date(chap.releaseDate).toLocaleDateString()}</span>
+                      </div>
+                    )}
+                    {chap.views && (
+                      <div className="flex items-center gap-1">
+                        <svg className="w-3 h-3 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                        </svg>
+                        <span>{chap.views > 1000 ? (chap.views / 1000).toFixed(1) + 'K' : chap.views} views</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ComicChap;

--- a/frontend/src/components/Comics/ComicChap.jsx
+++ b/frontend/src/components/Comics/ComicChap.jsx
@@ -55,7 +55,7 @@ return (
       {chapters.map((chap) => (
         <div
           key={chap._id}
-          className="group bg-white hover:bg-gray-50 border-1 border-gray-200 transition-all duration-300 hover:shadow-lg"
+          className="group bg-white hover:bg-gray-50 border border-gray-200 transition-all duration-300 hover:shadow-lg"
           onClick={() => {
             setSelectedPdf({ url: chap.chapPdf, title: chap.title });
             navigate(`/comicChap/${comicId}/chapters/pdfView`);
@@ -63,19 +63,19 @@ return (
         >
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
             <div className="flex items-start sm:items-center w-full">
-              <div className="w-32 h-17 sm:w-32 sm:h-17 flex-shrink-0 flex items-center justify-center shadow-md">
+              <div className="w-32 h-[68px] sm:w-32 sm:h-[68px] flex-shrink-0 flex items-center justify-center shadow-md">
                 <img
                   src={chap.chapImage}
                   alt="Chapter"
                   className="w-full h-full object-fill"
                 />
               </div>
-              <div className="flex justify-between items-center w-full">
-                <h3 className="text-xl font-medium text-gray-800 truncate max-w-[200px] sm:max-w-xs ml-6">
+              <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center w-full ml-4 sm:ml-6 mt-2 sm:mt-0">
+                <h3 className="text-xl font-medium text-gray-800 truncate max-w-[200px] sm:max-w-xs">
                   {chap.title}
                 </h3>
                 {chap.releaseDate && (
-                  <span className="text-base font-normal text-gray-600 whitespace-nowrap mr-15">
+                  <span className="text-base font-normal text-gray-600 mt-1 sm:mt-0 sm:ml-auto whitespace-nowrap mr-8">
                     {new Date(chap.releaseDate).toLocaleDateString("en-US", {
                       month: "short",
                       day: "numeric",

--- a/frontend/src/services/ComicService.js
+++ b/frontend/src/services/ComicService.js
@@ -6,3 +6,15 @@ export const fetchComics = async () => {
     // console.log("RES in services: ", res);
     return res.data.data;
 }
+
+export const fetchChapter = async (comicId) => {
+    console.log(comicId)
+  try {
+    const res = await axios.get(`${BASE_URL}/api/comicChap/${comicId}/chapters`);
+    console.log(res);
+    return res.data.data; // assuming response structure is same as fetchComics
+  } catch (error) {
+    console.error("Error fetching chapters:", error);
+    throw error;
+  }
+};

--- a/frontend/src/services/ComicService.js
+++ b/frontend/src/services/ComicService.js
@@ -12,7 +12,7 @@ export const fetchChapter = async (comicId) => {
   try {
     const res = await axios.get(`${BASE_URL}/api/comicChap/${comicId}/chapters`);
     console.log(res);
-    return res.data.data; // assuming response structure is same as fetchComics
+    return res.data.data; 
   } catch (error) {
     console.error("Error fetching chapters:", error);
     throw error;


### PR DESCRIPTION
1. Fetched Comic Chapters data from the admin panel and displayed it on the user frontend.

2. When a user clicks on a comic cover, all the chapters of that comic are shown as cards on a new page.

3. Clicking on any chapter opens its PDF in a clean viewer with the chapter title shown at the top and a back button to return to the chapters list.

4. Added a condition to hide the Navbar and Footer on the PDF view page (routes with comicChap and pdfView) for a distraction-free reading experience. These components remain visible on all other pages.

5. Made the whole feature mobile responsive

User frontend - 
<img width="1920" height="1057" alt="screencapture-localhost-3001-comicChap-6885c96a193e1559f3440174-chapters-2025-08-05-23_02_29" src="https://github.com/user-attachments/assets/73348207-4d16-4a0c-9c69-edd3bfdecdac" />

Pdf view - 
<img width="1920" height="912" alt="screencapture-localhost-3001-comicChap-6885c96a193e1559f3440174-chapters-pdfView-2025-08-05-23_02_45" src="https://github.com/user-attachments/assets/201ee390-b13c-4243-8410-6fd200b10c11" />

Mobile width - 
<img width="450" height="1333" alt="screencapture-localhost-3001-comicChap-6885c96a193e1559f3440174-chapters-2025-08-05-23_03_15" src="https://github.com/user-attachments/assets/ab4bacb6-3d84-4321-94ef-811b7769813f" />

Pdf View - 
<img width="450" height="800" alt="screencapture-localhost-3001-comicChap-6885c96a193e1559f3440174-chapters-pdfView-2025-08-05-23_03_27" src="https://github.com/user-attachments/assets/cd6e57b0-29c7-4b87-a5b3-f5997d6a7954" />


